### PR TITLE
Implement the insertDL CLI command

### DIFF
--- a/SM64DSe.csproj
+++ b/SM64DSe.csproj
@@ -152,9 +152,13 @@
     <Compile Include="src\core\BiDictionaryOneToOne.cs" />
     <Compile Include="src\core\cli\options\CompileOptions.cs" />
     <Compile Include="src\core\cli\options\ExtractOptions.cs" />
+    <Compile Include="src\core\cli\options\FileInsertOptions.cs" />
+    <Compile Include="src\core\cli\options\InsertDLOptions.cs" />
     <Compile Include="src\core\cli\options\PatchOptions.cs" />
     <Compile Include="src\core\cli\CLIWorker.cs" />
     <Compile Include="src\core\cli\workers\Compiler.cs" />
+    <Compile Include="src\core\cli\workers\DLInserter.cs" />
+    <Compile Include="src\core\cli\workers\FileInserter.cs" />
     <Compile Include="src\core\cli\workers\Patcher.cs" />
     <Compile Include="src\core\Compression.cs" />
     <Compile Include="src\core\ConsoleUtils.cs" />
@@ -204,7 +208,9 @@
     <Compile Include="src\core\KuppaScript\KuppaScript.cs" />
     <Compile Include="src\core\KuppaScript\NumberInterpreter.cs" />
     <Compile Include="src\core\Level.cs" />
-    <Compile Include="src\core\LevelEditorForm.EditingHandler.cs" />
+    <Compile Include="src\core\LevelEditorForm.EditingHandler.cs">
+      <SubType>Form</SubType>
+    </Compile>
     <Compile Include="src\core\LevelObject.cs" />
     <Compile Include="src\core\ModelCache.cs" />
     <Compile Include="src\core\NARC.cs" />
@@ -333,10 +339,18 @@
     <Compile Include="src\ui\FormationForm.Designer.cs">
       <DependentUpon>FormationForm.cs</DependentUpon>
     </Compile>
-    <Compile Include="src\ui\FormControls\BackgroundImageDataGridView.cs" />
-    <Compile Include="src\ui\FormControls\MenuButton.cs" />
-    <Compile Include="src\ui\FormControls\ModelGLControl.cs" />
-    <Compile Include="src\ui\FormControls\PaletteColourGrid.cs" />
+    <Compile Include="src\ui\FormControls\BackgroundImageDataGridView.cs">
+      <SubType>Component</SubType>
+    </Compile>
+    <Compile Include="src\ui\FormControls\MenuButton.cs">
+      <SubType>Component</SubType>
+    </Compile>
+    <Compile Include="src\ui\FormControls\ModelGLControl.cs">
+      <SubType>UserControl</SubType>
+    </Compile>
+    <Compile Include="src\ui\FormControls\PaletteColourGrid.cs">
+      <SubType>Component</SubType>
+    </Compile>
     <Compile Include="src\ui\GraphicEditor.cs">
       <SubType>Form</SubType>
     </Compile>
@@ -445,7 +459,9 @@
     <Compile Include="src\ui\ParticleViewerForm.Designer.cs">
       <DependentUpon>ParticleViewerForm.cs</DependentUpon>
     </Compile>
-    <Compile Include="src\ui\PatchViewerForm.cs" />
+    <Compile Include="src\ui\PatchViewerForm.cs">
+      <SubType>Form</SubType>
+    </Compile>
     <Compile Include="src\ui\PatchViewerForm.Designer.cs" />
     <Compile Include="src\ui\ProgressDialog.cs">
       <SubType>Form</SubType>
@@ -517,7 +533,9 @@
       <DependentUpon>UshortEditorForm.cs</DependentUpon>
     </Compile>
     <Compile Include="src\utils\Templates\CommonTemplate.cs" />
-    <Compile Include="src\utils\Templates\PlatformTemplateForm.cs" />
+    <Compile Include="src\utils\Templates\PlatformTemplateForm.cs">
+      <SubType>Form</SubType>
+    </Compile>
     <Compile Include="src\utils\Templates\PlatformTemplateForm.designer.cs">
       <DependentUpon>PlatformTemplateForm.cs</DependentUpon>
     </Compile>
@@ -813,9 +831,7 @@
       <Install>true</Install>
     </BootstrapperPackage>
   </ItemGroup>
-  <ItemGroup>
-    <Folder Include="src\utils" />
-  </ItemGroup>
+  <ItemGroup />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
@@ -827,10 +843,7 @@
     <ZipDirectory SourceDirectory="bin\release" Overwrite="true" DestinationFile="$(MSBuildProjectDirectory)\bin\release.zip" />
   </Target>
   <Target Name="AfterBuild" AfterTargets="Build" Condition="'$(Configuration)'=='Release'">
-    <ZipDirectory
-            SourceDirectory="bin\release"
-            Overwrite="true"
-            DestinationFile="$(MSBuildProjectDirectory)\bin\release.zip" />
+    <ZipDirectory SourceDirectory="bin\release" Overwrite="true" DestinationFile="$(MSBuildProjectDirectory)\bin\release.zip" />
   </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/src/core/Patcher/PatchMaker.cs
+++ b/src/core/Patcher/PatchMaker.cs
@@ -18,6 +18,8 @@ namespace SM64DSe.Patcher
         DirectoryInfo romdir;
         uint m_CodeAddr;
 
+        const uint baseAddress = 0x02400000;
+
         public PatchMaker(DirectoryInfo romdir, uint codeAddr)
         {
             //handler = new Arm9BinaryHandler();
@@ -230,14 +232,12 @@ namespace SM64DSe.Patcher
 
         public byte[] MakeDynamicLibrary(Env[] envs = null)
         {
-            const uint baseAddress = 0x02400000;
-
             string additionalEnvs = "";
             if (envs != null)
             {
-                for (var i = 0; i < envs.Length; i++)
+                foreach (var env in envs)
                 {
-                    additionalEnvs += $"{envs[i].GetName()}={envs[i].GetValue()} ";
+                    additionalEnvs += $"{env.GetName()}={env.GetValue()} ";
                 }
             }
             
@@ -253,6 +253,11 @@ namespace SM64DSe.Patcher
             if (PatchCompiler.runProcess(make, romdir.FullName) != 0)
                 return null;
 
+            return MakeDynamicLibraryFromBinaries();
+        }
+
+        public byte[] MakeDynamicLibraryFromBinaries()
+        {
             byte[] code0 = File.ReadAllBytes(romdir.FullName + "/newcode.bin");
             byte[] code1 = File.ReadAllBytes(romdir.FullName + "/newcode1.bin");
 

--- a/src/core/Program.cs
+++ b/src/core/Program.cs
@@ -71,9 +71,10 @@ namespace SM64DSe
             }
             
             // If not, assume the first argument is the command
-            Parser.Default.ParseArguments<PatchOptions, CompileOptions>(args)
+            Parser.Default.ParseArguments<PatchOptions, CompileOptions, InsertDLOptions>(args)
                 .WithParsed<PatchOptions>(new core.cli.workers.Patcher().Execute)
-                .WithParsed<CompileOptions>(new core.cli.workers.Compiler().Execute);
+                .WithParsed<CompileOptions>(new core.cli.workers.Compiler().Execute)
+                .WithParsed<InsertDLOptions>(new core.cli.workers.DLInserter().Execute);
         }
     }
 }

--- a/src/core/cli/options/CompileOptions.cs
+++ b/src/core/cli/options/CompileOptions.cs
@@ -11,7 +11,7 @@ namespace SM64DSe.core.cli.options
     }
     
     [Verb("compile", HelpText = "Compile ")]
-    public class CompileOptions
+    public class CompileOptions : FileInsertOptions
     {
         [Value(1, Required = true, HelpText = "Output type (DL | OVERLAY | CLEAN)")]
         public CompileOptionsType Type { get; set; }
@@ -25,16 +25,7 @@ namespace SM64DSe.core.cli.options
         [Value(4, Required = false, HelpText = "Internal path to insert the result in.")]
         public string InternalPath { get; set; }
         
-        [Option("force", Required = false, HelpText = "Force the editor to patch the file when dealing with vanilla rom.")]
-        public bool Force { get; set; }
-        
         [Option('e', "env", HelpText = "Environment variable for the makefile.\nE.g. --env SOURCES=sources/peach/")]
         public IEnumerable<string>Env { get; set; }
-        
-        [Option("create", Required = false, HelpText = "Create the file entry if it does not exist.")]
-        public bool Create { get; set; }
-        
-        [Option('r',"recursive", Required = false, HelpText = "Create parent directory of the file you want to create. Has no effect if --create is not provided.")]
-        public bool Recursive { get; set; }
     }
 }

--- a/src/core/cli/options/FileInsertOptions.cs
+++ b/src/core/cli/options/FileInsertOptions.cs
@@ -1,0 +1,17 @@
+using CommandLine;
+
+namespace SM64DSe.core.cli
+{
+    // meant to be used as a base class
+    public class FileInsertOptions
+    {
+        [Option("force", Required = false, HelpText = "Force the editor to patch the file when dealing with vanilla rom.")]
+        public bool Force { get; set; }
+
+        [Option("create", Required = false, HelpText = "Create the file entry if it does not exist.")]
+        public bool Create { get; set; }
+
+        [Option('r', "recursive", Required = false, HelpText = "Create parent directory of the file you want to create. Has no effect if --create is not provided.")]
+        public bool Recursive { get; set; }
+    }
+}

--- a/src/core/cli/options/InsertDLOptions.cs
+++ b/src/core/cli/options/InsertDLOptions.cs
@@ -1,0 +1,17 @@
+﻿using CommandLine;
+
+namespace SM64DSe.core.cli
+{
+    [Verb("insertDL", HelpText = "Generate a DL from precompiled binaries and insert it to the ROM")]
+    public class InsertDLOptions : FileInsertOptions
+    {
+        [Value(0, Required = true, HelpText = "Path to the rom")]
+        public string RomPath { get; set; }
+
+        [Value(1, Required = true, HelpText = "Path to the build folder")]
+        public string BuildFolderPath { get; set; }
+
+        [Value(2, Required = true, HelpText = "Path to the target list")]
+        public string TargetListPath { get; set; }
+    }
+}

--- a/src/core/cli/workers/Compiler.cs
+++ b/src/core/cli/workers/Compiler.cs
@@ -80,66 +80,8 @@ namespace SM64DSe.core.cli.workers
             }
             
             byte[] data = pm.MakeDynamicLibrary(environments.ToArray());
-            
-            if (Program.m_ROM.FileExists(options.InternalPath))
-            {
-                Log.Warning($"Replacing {options.InternalPath} with the dynamic library content.");
-                NitroFile dlFile = Program.m_ROM.GetFileFromName(options.InternalPath);
-                dlFile.m_Data = data;
-                dlFile.SaveChanges();
-            }
-            else if(options.Create)
-            {
-                Log.Warning($"You used --create option, it will change the filesystem.");
-                Program.m_ROM.StartFilesystemEdit(); // Start editing mode
-                 
-                string[] splitted = options.InternalPath.Split('/');
-                string pathBuilder = "";
-                for (var i = 0; i < splitted.Length - 1; i++)
-                {
-                    string tmp = $"{pathBuilder}{splitted[i]}/";
-                    
-                    // Check if the directory does not exist.
-                    if (Program.m_ROM.GetDirIDFromName(tmp) == 0)
-                    {
-                        if (options.Recursive)
-                        {
-                            if (pathBuilder.Length == 0)
-                            {
-                                throw new InvalidOperationException("Cannot create directory in root.");
-                            }
-                            else
-                            {
-                                Log.Warning($"Creating internal directory {tmp}.");
-                                Program.m_ROM.AddDir(pathBuilder, splitted[i], GetFilesystemRoot());
-                            }
-                        }
-                        else
-                        {
-                            throw new DirectoryNotFoundException(
-                                $"Internal directory {pathBuilder} not found in the ROM. Use --recursive option to create them.");
-                        }
-                    }
-                    
-                    pathBuilder = tmp;
-                }
-                
-                // add to file system
-                Program.m_ROM.AddFile(pathBuilder, splitted[splitted.Length - 1], data, GetFilesystemRoot());
-                // save
-                Program.m_ROM.SaveFilesystem();
-            }
-            else
-            {
-                throw new FileNotFoundException($"You tried to compile and insert a dynamic library to a non-existent file ({options.InternalPath}). If you want to create it you can use --create option.");
-            }
-        }
 
-        private static TreeNode GetFilesystemRoot()
-        {
-            TreeView fileTree = new TreeView();
-            ROMFileSelect.LoadFileList(fileTree);
-            return fileTree.Nodes[0];
+            FileInserter.InsertFile(options.InternalPath, data, options);
         }
     }
 }

--- a/src/core/cli/workers/DLInserter.cs
+++ b/src/core/cli/workers/DLInserter.cs
@@ -1,0 +1,94 @@
+﻿using System;
+using System.IO;
+using Serilog;
+using SM64DSe.Patcher;
+
+namespace SM64DSe.core.cli.workers
+{
+    public class DLInserter : CLIWorker<InsertDLOptions>
+    {
+        public override void Execute(InsertDLOptions options)
+        {
+            this.SetupRom(options.RomPath);
+
+            // Ensure the build folder exists
+            if (!Directory.Exists(options.BuildFolderPath))
+            {
+                Log.Error($"Folder {options.BuildFolderPath} not found.");
+                Environment.Exit(1);
+                return;
+            }
+
+            // Ensure the target list file exists
+            if (!File.Exists(options.TargetListPath))
+            {
+                Log.Error($"Target list {options.TargetListPath} not found.");
+                Environment.Exit(1);
+                return;
+            }
+
+            this.EnsurePatch(options.Force);
+
+            try
+            {
+                using (StreamReader reader = new StreamReader(options.TargetListPath))
+                {
+                    while (!reader.EndOfStream)
+                    {
+                        string line = reader.ReadLine();
+
+                        if (!string.IsNullOrWhiteSpace(line))
+                        {
+                            // Split the line at the first colon
+                            string[] parts = line.Split(new [] {':'}, 2);
+
+                            if (parts.Length != 2)
+                            {
+                                Log.Error($"Invalid syntax in {options.TargetListPath}: {line}");
+                                Environment.Exit(1);
+                                return;
+                            }
+
+                            string folderName = parts[0].Trim();
+                            string folderPath = Path.Combine(options.BuildFolderPath, folderName);
+                            string internalPath = parts[1].Trim();
+
+                            string codePath0 = Path.Combine(folderPath, "newcode.bin");
+                            string codePath1 = Path.Combine(folderPath, "newcode1.bin");
+
+                            // Ensure the binaries exist
+                            foreach (var path in new[] {codePath0, codePath1})
+                            {
+                                if (!File.Exists(path))
+                                {
+                                    Log.Error($"Binary file {path} not found.");
+                                    Environment.Exit(1);
+                                    return;
+                                }
+                            }
+
+                            PatchMaker pm = new PatchMaker(
+                                new DirectoryInfo(folderPath),
+                                0x02400000
+                            );
+
+                            byte[] dl = pm.MakeDynamicLibraryFromBinaries();
+
+                            if (dl != null)
+                            {
+                                Log.Information($"Created DL from '{folderName}'");
+
+                                FileInserter.InsertFile(internalPath, dl, options);
+                            }
+                        }
+                    }
+                }
+            }
+            catch (IOException ex)
+            {
+                Log.Error($"Error reading the target list: {ex.Message}");
+                Environment.Exit(1);
+            }
+        }
+    }
+}

--- a/src/core/cli/workers/FileInserter.cs
+++ b/src/core/cli/workers/FileInserter.cs
@@ -1,0 +1,73 @@
+﻿using System;
+using System.IO;
+using System.Windows.Forms;
+using Serilog;
+
+namespace SM64DSe.core.cli.workers
+{
+    public class FileInserter
+    {
+        public static void InsertFile(string internalPath, byte[] data, FileInsertOptions options)
+        {
+            if (Program.m_ROM.FileExists(internalPath))
+            {
+                Log.Warning($"Replacing {internalPath} with the dynamic library content.");
+                NitroFile dlFile = Program.m_ROM.GetFileFromName(internalPath);
+                dlFile.m_Data = data;
+                dlFile.SaveChanges();
+            }
+            else if(options.Create)
+            {
+                Log.Warning($"You used --create option, it will change the filesystem.");
+                Program.m_ROM.StartFilesystemEdit(); // Start editing mode
+                 
+                string[] splitted = internalPath.Split('/');
+                string pathBuilder = "";
+                for (var i = 0; i < splitted.Length - 1; i++)
+                {
+                    string tmp = $"{pathBuilder}{splitted[i]}/";
+                    
+                    // Check if the directory does not exist.
+                    if (Program.m_ROM.GetDirIDFromName(tmp) == 0)
+                    {
+                        if (options.Recursive)
+                        {
+                            if (pathBuilder.Length == 0)
+                            {
+                                throw new InvalidOperationException("Cannot create directory in root.");
+                            }
+                            else
+                            {
+                                Log.Warning($"Creating internal directory {tmp}.");
+                                Program.m_ROM.AddDir(pathBuilder, splitted[i], GetFilesystemRoot());
+                            }
+                        }
+                        else
+                        {
+                            throw new DirectoryNotFoundException(
+                                $"Internal directory {pathBuilder} not found in the ROM. Use --recursive option to create them.");
+                        }
+                    }
+                    
+                    pathBuilder = tmp;
+                }
+                
+                // add to file system
+                Program.m_ROM.AddFile(pathBuilder, splitted[splitted.Length - 1], data, GetFilesystemRoot());
+                // save
+                Program.m_ROM.SaveFilesystem();
+            }
+            else
+            {
+                throw new FileNotFoundException($"You tried to compile and insert a dynamic library to a non-existent file ({internalPath}). If you want to create it you can use --create option.");
+            }
+        }
+
+        private static TreeNode GetFilesystemRoot()
+        {
+            TreeView fileTree = new TreeView();
+            ROMFileSelect.LoadFileList(fileTree);
+            return fileTree.Nodes[0];
+        }
+    }
+}


### PR DESCRIPTION
This PR adds a new command to the CLI that can be used to construct multiple dynamic libraries from already compiled binaries and insert them to the rom. It's intended to be used in makefiles to let them have control over the build process.

## Usage
```
SM64DSe.exe insertDL [ROM path] [Build folder path] [Target list path] [--force] [--create] [--recursive]
```
In this case, the "build folder" should contain a subfolder for each DL with the same name as its source folder, and it should contain the binaries `newcode.bin` and `newcode1.bin` for the DL. The target list should be a text file that maps each of those subfolders into an internal file in the rom. Here's an example:
```
infinite_floor: data/enemy/peach/peach_jump.bca
test_cutscene:  data/enemy/peach/peach_jump_end.bca
```

Each folder/internal file pair should be on its own line and separated from each other by a colon.

This command also supports three of the same flags as the `compile` command, `--force`, `--create` and `--recursive`. They're all related to how the resulting DL should be inserted to the ROM file system. The code that handles that was moved to [its own file](https://github.com/pants64DS/SM64DSe-Ultimate/blob/master/src/core/cli/workers/FileInserter.cs), and it's now shared between the `compile` and `insertDL` commands.