### PR TITLE
Fix insertDLs options --newcode-lo and --newcode-hi

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,16 +65,18 @@ The `insertDLs` command will use already built binaries to generate one or many 
 SM64DSe.exe insertDLs [ROM-FILE] [BUILD-FOLDER] [TARGETS-FILE]
 
 # flags
-+ `--newcode-lo` (Default `newcode_lo.bin`)
-+ `--newcode-hi` (Default `newcode_hi.bin`)
++ `--newcode-lo` (Default `newcode_lo`)
++ `--newcode-hi` (Default `newcode_hi`)
 
 + `--force` force the editor to use the required patch on the rom
 + `--create` if the internal path does not exist, the file will be created, by default it replaces an existing one.
 + `--recursive` if the internal path provided does not exist, create the parent directory.
 
+The options `--newcode-lo` and `--newcode-hi` can be used to specify the names of the input files **without extensions**. The command assumes that each targeted folder contains two `.bin` files with the given filenames (`newcode_lo.bin` and `newcode_hi.bin` by default), and a `.sym` file with the name specified with `--newcode-lo` (or `newcode_lo.sym` by default).
+
 # Example
 
-SM64DSe.exe insertDLs ./europe.nds ./build ./targets.json --newcode-lo=newcode.bin --newcode-hi=newcode1.bin
+SM64DSe.exe insertDLs ./europe.nds ./build ./targets.json --newcode-lo=newcode --newcode-hi=newcode1
 
 ````
 

--- a/README.md
+++ b/README.md
@@ -72,13 +72,12 @@ SM64DSe.exe insertDLs [ROM-FILE] [BUILD-FOLDER] [TARGETS-FILE]
 + `--create` if the internal path does not exist, the file will be created, by default it replaces an existing one.
 + `--recursive` if the internal path provided does not exist, create the parent directory.
 
-The options `--newcode-lo` and `--newcode-hi` can be used to specify the names of the input files **without extensions**. The command assumes that each targeted folder contains two `.bin` files with the given filenames (`newcode_lo.bin` and `newcode_hi.bin` by default), and a `.sym` file with the name specified with `--newcode-lo` (or `newcode_lo.sym` by default).
-
 # Example
 
 SM64DSe.exe insertDLs ./europe.nds ./build ./targets.json --newcode-lo=newcode --newcode-hi=newcode1
-
 ````
+
+The options `--newcode-lo` and `--newcode-hi` can be used to specify the names of the input files **without extensions**. The command assumes that each targeted folder contains two `.bin` files with the given filenames (`newcode_lo.bin` and `newcode_hi.bin` by default), and a `.sym` file with the name specified with `--newcode-lo` (or `newcode_lo.sym` by default).
 
 ⚠️ The editor **will not** build the binaries for you, you need to execute `make` or any building process ahead. This will only combine for each target the existing `newcode_lo` and `newcode_hi` in a dynamic library.
 

--- a/src/core/Patcher/PatchMaker.cs
+++ b/src/core/Patcher/PatchMaker.cs
@@ -172,7 +172,7 @@ namespace SM64DSe.Patcher
             }
         }
 
-        private (uint, uint)? getInitAndCleanup()
+        private (uint, uint)? getInitAndCleanup(string symFileName)
         {
             StreamReader symbolFile = null;
             uint initFuncOffset  = 0;
@@ -180,7 +180,7 @@ namespace SM64DSe.Patcher
 
             try
             {
-                symbolFile = new StreamReader(new FileStream(romdir.FullName + "/newcode.sym", FileMode.Open));
+                symbolFile = new StreamReader(new FileStream($"{romdir.FullName}/{symFileName}", FileMode.Open));
 
                 while (!symbolFile.EndOfStream)
                 {
@@ -256,10 +256,10 @@ namespace SM64DSe.Patcher
             return MakeDynamicLibraryFromBinaries();
         }
 
-        public byte[] MakeDynamicLibraryFromBinaries()
+        public byte[] MakeDynamicLibraryFromBinaries(string codeLo = "/newcode", string codeHi = "/newcode1")
         {
-            byte[] code0 = File.ReadAllBytes(romdir.FullName + "/newcode.bin");
-            byte[] code1 = File.ReadAllBytes(romdir.FullName + "/newcode1.bin");
+            byte[] code0 = File.ReadAllBytes($"{romdir.FullName}/{codeLo}.bin");
+            byte[] code1 = File.ReadAllBytes($"{romdir.FullName}/{codeHi}.bin");
 
             if (code0.Length != code1.Length)
                 throw new Exception("Generating DL failed: code lengths don't match");
@@ -309,7 +309,7 @@ namespace SM64DSe.Patcher
             alignStream(output.BaseStream, 4);
 
             var relocationOffset = output.BaseStream.Position;
-            var addresses = getInitAndCleanup();
+            var addresses = getInitAndCleanup(codeLo + ".sym");
             if (addresses == null) return null;
 
             uint initFuncOffset  = (((uint, uint))addresses).Item1 - baseAddress + 0x10;

--- a/src/core/cli/options/InsertDLsOptions.cs
+++ b/src/core/cli/options/InsertDLsOptions.cs
@@ -14,10 +14,10 @@ namespace SM64DSe.core.cli
         [Value(2, Required = true, HelpText = "Path to the target list")]
         public string TargetListPath { get; set; }
         
-        [Option("newcode-lo", Required = false, HelpText = "", Default = "newcode_lo.bin")]
+        [Option("newcode-lo", Required = false, HelpText = "", Default = "newcode_lo")]
         public string NewCodeLo { get; set; }
         
-        [Option("newcode-hi", Required = false, HelpText = "", Default = "newcode_hi.bin")]
+        [Option("newcode-hi", Required = false, HelpText = "", Default = "newcode_hi")]
         public string NewCodeHi { get; set; }
     }
 }

--- a/src/core/cli/workers/DLsInserter.cs
+++ b/src/core/cli/workers/DLsInserter.cs
@@ -40,15 +40,16 @@ namespace SM64DSe.core.cli.workers
             {
                 string folderPath = Path.Combine(options.BuildFolderPath, target.Key);
                 
-                string codePath0 = Path.Combine(folderPath, options.NewCodeLo);
-                string codePath1 = Path.Combine(folderPath, options.NewCodeHi);
+                string symFilePath   = Path.Combine(folderPath, options.NewCodeLo + ".sym");
+                string loBinFilePath = Path.Combine(folderPath, options.NewCodeLo + ".bin");
+                string hiBinFilePath = Path.Combine(folderPath, options.NewCodeHi + ".bin");
                 
                 // Ensure the binaries exist
-                foreach (var path in new[] {codePath0, codePath1})
+                foreach (var path in new[] {symFilePath, loBinFilePath, hiBinFilePath})
                 {
                     if (!File.Exists(path))
                     {
-                        Log.Error($"Binary file {path} not found.");
+                        Log.Error($"Required file '{path}' not found.");
                         Environment.Exit(1);
                         return;
                     }
@@ -59,7 +60,7 @@ namespace SM64DSe.core.cli.workers
                     0x02400000
                 );
 
-                byte[] dl = pm.MakeDynamicLibraryFromBinaries();
+                byte[] dl = pm.MakeDynamicLibraryFromBinaries(options.NewCodeLo, options.NewCodeHi);
 
                 if (dl != null)
                 {


### PR DESCRIPTION
This fixes the options  `--newcode-lo` and `--newcode-hi` not working for the `insertDLs` command. These options are also changed so that the filenames specified with them should no longer have file extensions (`.bin`) because a `.sym` file with the name specified with `--newcode-lo` is also used.

:warning: **Note:** Before this fix, the `insertDLs` command didn't actually work in most cases even when these flags weren't used. This was because their default values were `newcode_lo.bin` and `newcode_hi.bin`, and those files were required to exist even though the files actually used to generate the DL were `newcode.bin`, `newcode1.bin` and `newcode.sym`, as they were hardcoded.