### PR TITLE
Display unhandled exceptions correctly when the CLI is called from a makefile

### DIFF
--- a/src/core/Program.cs
+++ b/src/core/Program.cs
@@ -69,12 +69,20 @@ namespace SM64DSe
                 Application.Run(new MainForm(path));
                 return;
             }
-            
+
             // If not, assume the first argument is the command
-            Parser.Default.ParseArguments<PatchOptions, CompileOptions, InsertDLsOptions>(args)
-                .WithParsed<PatchOptions>(new core.cli.workers.Patcher().Execute)
-                .WithParsed<CompileOptions>(new core.cli.workers.Compiler().Execute)
-                .WithParsed<InsertDLsOptions>(new core.cli.workers.DLsInserter().Execute);
+            try
+            {
+                Parser.Default.ParseArguments<PatchOptions, CompileOptions, InsertDLsOptions>(args)
+                    .WithParsed<PatchOptions>(new core.cli.workers.Patcher().Execute)
+                    .WithParsed<CompileOptions>(new core.cli.workers.Compiler().Execute)
+                    .WithParsed<InsertDLsOptions>(new core.cli.workers.DLsInserter().Execute);
+            }
+            catch (Exception e)
+            {
+                Log.Error(e.ToString());
+                Environment.Exit(1);
+            }
         }
     }
 }


### PR DESCRIPTION
Previously, when the CLI was called from a makefile and an unhandled exception occurred, only an error message from `make` was shown (e.g. `make: *** [Makefile:21: all] Error 127`) and nothing about the exception itself. This fixes that so that the full exception is printed.

#### Before:
```
C:\Users\Asus\Desktop\Misc-SM64DS-Patches\dynamic_lib>make
building DL 'infinite_floor' ...
make[1]: Nothing to be done for 'all'.
building DL 'test_cutscene' ...
make[1]: Nothing to be done for 'all'.
"C:\Users\Asus\Documents\SM64DSe\SM64DSe-Ultimate\bin\Release\SM64DSe.exe" insertDLs "../da rom.nds" build targets.txt
[17:57:50 INF] SM64DSe-Ultimate version v3.2.0
make: *** [Makefile:21: all] Error 127

C:\Users\Asus\Desktop\Misc-SM64DS-Patches\dynamic_lib>
```
#### After:
```
C:\Users\Asus\Desktop\Misc-SM64DS-Patches\dynamic_lib>make
building DL 'infinite_floor' ...
make[1]: Nothing to be done for 'all'.
building DL 'test_cutscene' ...
make[1]: Nothing to be done for 'all'.
"C:\Users\Asus\Documents\SM64DSe\SM64DSe-Ultimate\bin\Release\SM64DSe.exe" insertDLs "../da rom.nds" build targets.txt
[18:02:37 INF] SM64DSe-Ultimate version v3.2.0
[18:02:37 ERR] System.Exception: Generating DL failed: code files don't match for an unknown reason
newcode.bin offset: 0x004C
mismatching words: 0xEBF0E44C and 0xEBF0E43B
   at SM64DSe.Patcher.PatchMaker.MakeDynamicLibraryFromBinaries(String codeLo, String codeHi) in C:\Users\Asus\Documents\SM64DSe\SM64DSe-Ultimate\src\core\Patcher\PatchMaker.cs:line 300
   at SM64DSe.core.cli.workers.DLsInserter.Execute(InsertDLsOptions options) in C:\Users\Asus\Documents\SM64DSe\SM64DSe-Ultimate\src\core\cli\workers\DLsInserter.cs:line 58
   at CommandLine.ParserResultExtensions.WithParsed[T](ParserResult`1 result, Action`1 action)
   at SM64DSe.Program.Main(String[] args) in C:\Users\Asus\Documents\SM64DSe\SM64DSe-Ultimate\src\core\Program.cs:line 52
make: *** [Makefile:21: all] Error 1

C:\Users\Asus\Desktop\Misc-SM64DS-Patches\dynamic_lib>
```